### PR TITLE
- Contraints outputs now depend on the parser

### DIFF
--- a/src/main/java/com/squiggle/base/ColumnDef.java
+++ b/src/main/java/com/squiggle/base/ColumnDef.java
@@ -3,6 +3,7 @@ package com.squiggle.base;
 import java.util.List;
 
 import com.squiggle.constraints.Constraint;
+import com.squiggle.constraints.PrimaryKey;
 import com.squiggle.output.Output;
 import com.squiggle.output.Outputable;
 import com.squiggle.types.definitions.TypeDef;
@@ -19,15 +20,52 @@ public class ColumnDef implements Outputable {
         this.constraints = constraints;
     }
 
-    @Override
-    public void write(Output out) {
+    public void write(Output out, Boolean withConstraints) {
+        out.print(name);
+        out.space();
+        type.write(out);
+        if (withConstraints) {
+            for (Constraint constraint : constraints) {
+                out.space();
+                constraint.write(out);
+            }
+        }
+
+    }
+
+    public void write(Output out, List<Class> constraintClasses) {
         out.print(name);
         out.space();
         type.write(out);
         for (Constraint constraint : constraints) {
-            out.space();
-            constraint.write(out);
+            if (!constraintClasses.contains(constraint.getClass())) {
+                out.space();
+                constraint.write(out);
+            }
         }
+
+    }
+
+    @Override
+    public void write(Output out) {
+        write(out, true);
+    }
+
+    public Boolean isPrimaryKey() {
+        for (Constraint constraint : constraints) {
+            if (constraint instanceof PrimaryKey) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<Constraint> getConstraints() {
+        return constraints;
+    }
+
+    public String getName() {
+        return name;
     }
 
 }

--- a/src/main/java/com/squiggle/builders/ColumnDefBuilder.java
+++ b/src/main/java/com/squiggle/builders/ColumnDefBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.squiggle.base.ColumnDef;
 import com.squiggle.constraints.Constraint;
+import com.squiggle.constraints.ForeignKey;
 import com.squiggle.constraints.NotNullable;
 import com.squiggle.constraints.Nullable;
 import com.squiggle.constraints.PrimaryKey;
@@ -86,6 +87,11 @@ public class ColumnDefBuilder {
 
     public ColumnDefBuilder unique() {
         this.constraints.add(new Unique());
+        return this;
+    }
+
+    public ColumnDefBuilder foreignKey(String table, String foreignColumn) {
+        this.constraints.add(new ForeignKey(name, table, foreignColumn));
         return this;
     }
 

--- a/src/main/java/com/squiggle/constraints/Constraint.java
+++ b/src/main/java/com/squiggle/constraints/Constraint.java
@@ -1,11 +1,21 @@
 package com.squiggle.constraints;
 
+import com.squiggle.Squiggle;
 import com.squiggle.output.Outputable;
+import com.squiggle.parsers.Parser;
 
 public abstract class Constraint implements Outputable {
 
+    protected Parser parser;
+
+    public Constraint(Parser parser) {
+        super();
+        this.parser = parser;
+    }
+
     public Constraint() {
         super();
+        this.parser = Squiggle.getParser();
     }
 
 }

--- a/src/main/java/com/squiggle/constraints/ForeignKey.java
+++ b/src/main/java/com/squiggle/constraints/ForeignKey.java
@@ -1,0 +1,37 @@
+package com.squiggle.constraints;
+
+import com.squiggle.output.Output;
+
+public class ForeignKey extends Constraint {
+
+    private String columnName;
+    private String tableName;
+    private String foreignColumnName;
+
+    public ForeignKey(String columnName, String tableName, String foreignColumnName) {
+        super();
+        this.columnName = columnName;
+        this.tableName = tableName;
+        this.foreignColumnName = foreignColumnName;
+    }
+
+    // Fix to the right form
+    // parser should be responsible for this.
+    @Override
+    public void write(Output out) {
+        this.parser.foreignKey(out, this);
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getForeignColumnName() {
+        return foreignColumnName;
+    }
+
+}

--- a/src/main/java/com/squiggle/constraints/NotNullable.java
+++ b/src/main/java/com/squiggle/constraints/NotNullable.java
@@ -6,7 +6,7 @@ public class NotNullable extends Constraint {
 
     @Override
     public void write(Output out) {
-        out.print("NOT NULL");
+        parser.notNullable(out, this);
     }
 
 }

--- a/src/main/java/com/squiggle/constraints/Nullable.java
+++ b/src/main/java/com/squiggle/constraints/Nullable.java
@@ -6,8 +6,7 @@ public class Nullable extends Constraint {
 
     @Override
     public void write(Output out) {
-        out.print("NULL");
-
+        parser.nullable(out, this);
     }
 
 }

--- a/src/main/java/com/squiggle/constraints/PrimaryKey.java
+++ b/src/main/java/com/squiggle/constraints/PrimaryKey.java
@@ -6,7 +6,7 @@ public class PrimaryKey extends Constraint {
 
     @Override
     public void write(Output out) {
-        out.print("PRIMARY KEY");
+        parser.primaryKey(out, this);
     }
 
 }

--- a/src/main/java/com/squiggle/constraints/Unique.java
+++ b/src/main/java/com/squiggle/constraints/Unique.java
@@ -6,7 +6,8 @@ public class Unique extends Constraint {
 
     @Override
     public void write(Output out) {
-        out.print("UNIQUE");
+        parser.unique(out, this);
+
     }
 
 }

--- a/src/main/java/com/squiggle/parsers/Parser.java
+++ b/src/main/java/com/squiggle/parsers/Parser.java
@@ -1,5 +1,10 @@
 package com.squiggle.parsers;
 
+import com.squiggle.constraints.ForeignKey;
+import com.squiggle.constraints.NotNullable;
+import com.squiggle.constraints.Nullable;
+import com.squiggle.constraints.PrimaryKey;
+import com.squiggle.constraints.Unique;
 import com.squiggle.output.Output;
 import com.squiggle.queries.CreateTableQuery;
 import com.squiggle.queries.DeleteQuery;
@@ -22,5 +27,15 @@ public abstract class Parser {
     public abstract void deleteQuery(Output out, DeleteQuery deleteQuery);
 
     public abstract void createTableQuery(Output out, CreateTableQuery createTableQuery);
+
+    public abstract void foreignKey(Output out, ForeignKey foreignKey);
+
+    public abstract void notNullable(Output out, NotNullable notNullable);
+
+    public abstract void nullable(Output out, Nullable nullable);
+
+    public abstract void primaryKey(Output out, PrimaryKey primaryKey);
+
+    public abstract void unique(Output out, Unique unique);
 
 }

--- a/src/main/java/com/squiggle/queries/CreateTableQuery.java
+++ b/src/main/java/com/squiggle/queries/CreateTableQuery.java
@@ -91,6 +91,15 @@ public class CreateTableQuery extends Parserable implements Outputable, Validata
         return this.primaryKey();
     }
 
+    public CreateTableQuery foreignKey(String table, String foreignColumn) {
+        this.columnDefBuilder.foreignKey(table, foreignColumn);
+        return this;
+    }
+
+    public CreateTableQuery fk(String table, String foreignColumn) {
+        return this.foreignKey(table, foreignColumn);
+    }
+
     public CreateTableQuery define() {
         this.columnsDefs.add(this.columnDefBuilder.build());
         this.columnDefBuilder.reset();

--- a/src/test/java/CreateTableConstraintTest.java
+++ b/src/test/java/CreateTableConstraintTest.java
@@ -28,6 +28,39 @@ public class CreateTableConstraintTest {
         }
 
         @Test
+        public void compositePK() {
+                CreateTableQuery createTableQuery = Squiggle.CreateTable("table")
+                                .column("column1").varchar().pk().define()
+                                .column("column2").varchar().pk().define();
+                assertEquals(
+                                "CREATE TABLE table (column1 varchar(255), column2 varchar(255), PRIMARY KEY (column1, column2))",
+                                createTableQuery.toString());
+        }
+
+        @Test
+        public void tripleCompositePK() {
+                CreateTableQuery createTableQuery = Squiggle.CreateTable("table")
+                                .column("column1").varchar(20).pk().define()
+                                .column("column2").integer().pk().define()
+                                .column("column3").date().pk().define();
+                assertEquals(
+                                "CREATE TABLE table (column1 varchar(20), column2 int, column3 date, PRIMARY KEY (column1, column2, column3))",
+                                createTableQuery.toString());
+        }
+
+        @Test
+        public void tripleCompositePKandOneFK() {
+                CreateTableQuery createTableQuery = Squiggle.CreateTable("table")
+                                .column("column1").varchar(20).pk().define()
+                                .column("column2").integer().pk().define()
+                                .column("column3").date().pk().define()
+                                .column("column4").varchar().fk("table2", "foreignColumn").define();
+                assertEquals(
+                                "CREATE TABLE table (column1 varchar(20), column2 int, column3 date, column4 varchar(255) FOREIGN KEY REFERENCES table2(foreignColumn), PRIMARY KEY (column1, column2, column3))",
+                                createTableQuery.toString());
+        }
+
+        @Test
         public void defineNullableColumn() {
                 CreateTableQuery createTableQuery = Squiggle.CreateTable("table")
                                 .column("column1").varchar().nullable().define();
@@ -51,6 +84,14 @@ public class CreateTableConstraintTest {
                                 .column("column1").varchar().unique().define();
                 assertEquals(
                                 "CREATE TABLE table (column1 varchar(255) UNIQUE)",
+                                createTableQuery.toString());
+        }
+
+        @Test
+        public void defineForeignKey() {
+                CreateTableQuery createTableQuery = Squiggle.CreateTable("table")
+                                .column("column1").varchar().fk("table2", "foreignColumn").define();
+                assertEquals("CREATE TABLE table (column1 varchar(255) FOREIGN KEY REFERENCES table2(foreignColumn))",
                                 createTableQuery.toString());
         }
 }

--- a/src/test/java/UpdateQueryTest.java
+++ b/src/test/java/UpdateQueryTest.java
@@ -2,7 +2,6 @@
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Random;
 import java.util.SplittableRandom;
 
 import com.squiggle.Squiggle;


### PR DESCRIPTION
- ColumnDef can now be printed by specifying which constraints to remove
- foreignKey added to ColumnDefBuilder
- Multiple Primary Keys are now printed
 at the end of the Table definition
 - CreateTableContraintTests added