### PR TITLE
1.6.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 .classpath
 .project
+/src/test/java/resources/database.properties

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.vscode
 .classpath
 .project
-/src/test/java/resources/database.properties
+src/test/java/resources/database.properties

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com</groupId>
     <artifactId>squiggle</artifactId>
-    <version>1.6.6</version>
+    <version>1.6.6.1</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com</groupId>
     <artifactId>squiggle</artifactId>
-    <version>1.6.6.1</version>
+    <version>1.6.7</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/com/squiggle/Squiggle.java
+++ b/src/main/java/com/squiggle/Squiggle.java
@@ -42,6 +42,10 @@ public class Squiggle {
         return new DropDatabaseQuery(databaseName);
     }
 
+    public static TransactionQuery Transaction() {
+        return new TransactionQuery();
+    }
+
     public static void setParser(Parser parser) {
         Squiggle.parser = parser;
     }

--- a/src/main/java/com/squiggle/base/Condition.java
+++ b/src/main/java/com/squiggle/base/Condition.java
@@ -5,6 +5,8 @@
  */
 package com.squiggle.base;
 
+import com.squiggle.builders.CriteriaBuilder;
+
 /**
  *
  * @author nmadeo

--- a/src/main/java/com/squiggle/base/Table.java
+++ b/src/main/java/com/squiggle/base/Table.java
@@ -34,7 +34,7 @@ public class Table extends Parserable {
     /**
      * Whether this table has an alias assigned.
      */
-    private boolean hasAlias() {
+    public boolean hasAlias() {
         return alias != null;
     }
 
@@ -73,11 +73,7 @@ public class Table extends Parserable {
     }
 
     public void write(Output out) {
-        out.print(getName());
-        if (hasAlias()) {
-            out.print(' ');
-            out.print(getAlias());
-        }
+        this.parser.table(out, this);
     }
 
     public String toString() {

--- a/src/main/java/com/squiggle/base/Transactables/Commit.java
+++ b/src/main/java/com/squiggle/base/Transactables/Commit.java
@@ -1,0 +1,25 @@
+package com.squiggle.base.Transactables;
+
+import com.squiggle.Squiggle;
+import com.squiggle.output.Output;
+import com.squiggle.parsers.Parser;
+
+public class Commit implements Transactable {
+
+    Parser parser;
+
+    public Commit(Parser parser) {
+        this.parser = parser;
+    }
+
+    public Commit() {
+        this.parser = Squiggle.getParser();
+
+    }
+
+    @Override
+    public void write(Output out) {
+        this.parser.commit(out, this);
+    }
+
+}

--- a/src/main/java/com/squiggle/base/Transactables/Rollback.java
+++ b/src/main/java/com/squiggle/base/Transactables/Rollback.java
@@ -1,0 +1,24 @@
+package com.squiggle.base.Transactables;
+
+import com.squiggle.Squiggle;
+import com.squiggle.output.Output;
+import com.squiggle.parsers.Parser;
+
+public class Rollback implements Transactable {
+
+    Parser parser;
+
+    public Rollback(Parser parser) {
+        this.parser = parser;
+    }
+
+    public Rollback() {
+        this.parser = Squiggle.getParser();
+    }
+
+    @Override
+    public void write(Output out) {
+        this.parser.rollback(out, this);
+    }
+
+}

--- a/src/main/java/com/squiggle/base/Transactables/Transactable.java
+++ b/src/main/java/com/squiggle/base/Transactables/Transactable.java
@@ -1,9 +1,6 @@
 package com.squiggle.base.Transactables;
 
-import com.squiggle.Squiggle;
-import com.squiggle.output.Output;
 import com.squiggle.output.Outputable;
-import com.squiggle.parsers.Parser;
 
 public interface Transactable extends Outputable {
 

--- a/src/main/java/com/squiggle/base/Transactables/Transactable.java
+++ b/src/main/java/com/squiggle/base/Transactables/Transactable.java
@@ -1,0 +1,10 @@
+package com.squiggle.base.Transactables;
+
+import com.squiggle.Squiggle;
+import com.squiggle.output.Output;
+import com.squiggle.output.Outputable;
+import com.squiggle.parsers.Parser;
+
+public interface Transactable extends Outputable {
+
+}

--- a/src/main/java/com/squiggle/builders/CriteriaBuilder.java
+++ b/src/main/java/com/squiggle/builders/CriteriaBuilder.java
@@ -3,9 +3,11 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package com.squiggle.base;
+package com.squiggle.builders;
 
 import java.util.Date;
+
+import com.squiggle.base.*;
 
 /**
  *

--- a/src/main/java/com/squiggle/constraints/Constraint.java
+++ b/src/main/java/com/squiggle/constraints/Constraint.java
@@ -9,12 +9,10 @@ public abstract class Constraint implements Outputable {
     protected Parser parser;
 
     public Constraint(Parser parser) {
-        super();
         this.parser = parser;
     }
 
     public Constraint() {
-        super();
         this.parser = Squiggle.getParser();
     }
 

--- a/src/main/java/com/squiggle/parsers/Parser.java
+++ b/src/main/java/com/squiggle/parsers/Parser.java
@@ -2,6 +2,8 @@ package com.squiggle.parsers;
 
 import com.squiggle.base.AggregatedColumn;
 import com.squiggle.base.Column;
+import com.squiggle.base.Transactables.Commit;
+import com.squiggle.base.Transactables.Rollback;
 import com.squiggle.constraints.AutoIncrement;
 import com.squiggle.constraints.DefaultValue;
 import com.squiggle.constraints.ForeignKey;
@@ -15,6 +17,7 @@ import com.squiggle.queries.DeleteQuery;
 import com.squiggle.queries.DropDatabaseQuery;
 import com.squiggle.queries.InsertQuery;
 import com.squiggle.queries.SelectQuery;
+import com.squiggle.queries.TransactionQuery;
 import com.squiggle.queries.UpdateQuery;
 import com.squiggle.queries.TableQueries.CreateTableQuery;
 import com.squiggle.queries.TableQueries.DropTableQuery;
@@ -66,5 +69,11 @@ public abstract class Parser {
     public abstract void average(Output out, AggregatedColumn aggregatedColumn);
 
     public abstract void count(Output out, AggregatedColumn aggregatedColumn);
+
+    public abstract void commit(Output out, Commit commit);
+
+    public abstract void rollback(Output out, Rollback rollback);
+
+    public abstract void transaction(Output out, TransactionQuery transactionQuery);
 
 }

--- a/src/main/java/com/squiggle/parsers/Parser.java
+++ b/src/main/java/com/squiggle/parsers/Parser.java
@@ -2,6 +2,7 @@ package com.squiggle.parsers;
 
 import com.squiggle.base.AggregatedColumn;
 import com.squiggle.base.Column;
+import com.squiggle.base.Table;
 import com.squiggle.base.Transactables.Commit;
 import com.squiggle.base.Transactables.Rollback;
 import com.squiggle.constraints.AutoIncrement;
@@ -75,5 +76,7 @@ public abstract class Parser {
     public abstract void rollback(Output out, Rollback rollback);
 
     public abstract void transaction(Output out, TransactionQuery transactionQuery);
+
+    public abstract void table(Output out, Table table);
 
 }

--- a/src/main/java/com/squiggle/parsers/SqlServerParser.java
+++ b/src/main/java/com/squiggle/parsers/SqlServerParser.java
@@ -101,7 +101,7 @@ public class SqlServerParser extends Parser {
             out.print("WHERE");
             out.space();
 
-            appendList(out, selectQuery.listCriteria(), "AND");
+            appendList(out, selectQuery.listCriteria(), " AND");
         }
 
         // Add group by

--- a/src/main/java/com/squiggle/parsers/SqlServerParser.java
+++ b/src/main/java/com/squiggle/parsers/SqlServerParser.java
@@ -13,6 +13,8 @@ import com.squiggle.base.ColumnDef;
 import com.squiggle.base.JoinCriteria;
 import com.squiggle.base.Row;
 import com.squiggle.base.Table;
+import com.squiggle.base.Transactables.Commit;
+import com.squiggle.base.Transactables.Rollback;
 import com.squiggle.constraints.AutoIncrement;
 import com.squiggle.constraints.DefaultValue;
 import com.squiggle.constraints.ForeignKey;
@@ -30,6 +32,7 @@ import com.squiggle.queries.DeleteQuery;
 import com.squiggle.queries.DropDatabaseQuery;
 import com.squiggle.queries.InsertQuery;
 import com.squiggle.queries.SelectQuery;
+import com.squiggle.queries.TransactionQuery;
 import com.squiggle.queries.UpdateQuery;
 import com.squiggle.queries.TableQueries.CreateTableQuery;
 import com.squiggle.queries.TableQueries.DropTableQuery;
@@ -459,6 +462,24 @@ public class SqlServerParser extends Parser {
     @Override
     public void aggregatedColumn(Output out, AggregatedColumn aggregatedColumn) {
         aggregatedColumn.getFunction().write(out, aggregatedColumn);
+
+    }
+
+    @Override
+    public void commit(Output out, Commit commit) {
+        out.print("COMMIT TRANSACTION");
+
+    }
+
+    @Override
+    public void rollback(Output out, Rollback rollback) {
+        out.print("ROLLBACK TRANSACTION");
+
+    }
+
+    @Override
+    public void transaction(Output out, TransactionQuery transactionQuery) {
+        // TODO Auto-generated method stub
 
     }
 

--- a/src/main/java/com/squiggle/queries/DeleteQuery.java
+++ b/src/main/java/com/squiggle/queries/DeleteQuery.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.Function;
 
 import com.squiggle.base.*;
+import com.squiggle.builders.CriteriaBuilder;
 import com.squiggle.output.*;
 
 /**

--- a/src/main/java/com/squiggle/queries/Query.java
+++ b/src/main/java/com/squiggle/queries/Query.java
@@ -3,13 +3,14 @@ package com.squiggle.queries;
 import java.util.*;
 
 import com.squiggle.base.*;
+import com.squiggle.base.Transactables.Transactable;
 import com.squiggle.exceptions.NoTableException;
 import com.squiggle.interfaces.Validatable;
 import com.squiggle.output.*;
 import com.squiggle.parsers.Parser;
 import com.squiggle.parsers.Parserable;
 
-public abstract class Query extends Parserable implements Validatable {
+public abstract class Query extends Parserable implements Validatable, Transactable {
 
     public static final int indentSize = 4;
 

--- a/src/main/java/com/squiggle/queries/SelectQuery.java
+++ b/src/main/java/com/squiggle/queries/SelectQuery.java
@@ -1,17 +1,26 @@
 package com.squiggle.queries;
 
-import java.util.*;
-import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
-import com.squiggle.base.*;
+import com.squiggle.base.Column;
+import com.squiggle.base.Criteria;
+import com.squiggle.base.JoinCriteria;
+import com.squiggle.base.NoCriteria;
+import com.squiggle.base.Order;
+import com.squiggle.base.Table;
+import com.squiggle.builders.CriteriaBuilder;
 import com.squiggle.exceptions.NoColumnsException;
 import com.squiggle.exceptions.NoTableException;
 import com.squiggle.functions.Average;
 import com.squiggle.functions.Count;
 import com.squiggle.functions.Sum;
-import com.squiggle.output.*;
-import com.squiggle.parsers.Parserable;
+import com.squiggle.output.Output;
 
 /**
  * @author <a href="joe@truemesh.com">Joe Walnes</a>

--- a/src/main/java/com/squiggle/queries/TransactionQuery.java
+++ b/src/main/java/com/squiggle/queries/TransactionQuery.java
@@ -1,0 +1,55 @@
+package com.squiggle.queries;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.squiggle.base.Transactables.Commit;
+import com.squiggle.base.Transactables.Rollback;
+import com.squiggle.base.Transactables.Transactable;
+import com.squiggle.output.Output;
+import com.squiggle.parsers.Parser;
+import com.squiggle.parsers.Parserable;
+
+/**
+ * @author <a href="joe@truemesh.com">Joe Walnes</a>
+ * @author nmadeo - Nicolas Madeo
+ */
+public class TransactionQuery extends Parserable {
+
+    List<Transactable> transactables;
+
+    public TransactionQuery() {
+        super();
+        this.transactables = new LinkedList<Transactable>();
+    }
+
+    public TransactionQuery(Parser parser) {
+        super(parser);
+        this.transactables = new LinkedList<Transactable>();
+    }
+
+    public TransactionQuery add(Query query) {
+        this.transactables.add(query);
+        return this;
+    }
+
+    private TransactionQuery add(Transactable transactable) {
+        this.transactables.add(transactable);
+        return this;
+    }
+
+    public TransactionQuery commit() {
+        return add(new Commit());
+    }
+
+    public TransactionQuery rollback() {
+        return add(new Rollback());
+    }
+
+    @Override
+    public void write(Output out) {
+        this.parser.transaction(out, this);
+
+    }
+
+}

--- a/src/main/java/com/squiggle/queries/TransactionQuery.java
+++ b/src/main/java/com/squiggle/queries/TransactionQuery.java
@@ -2,11 +2,15 @@ package com.squiggle.queries;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
+import com.squiggle.Squiggle;
 import com.squiggle.base.Transactables.Commit;
 import com.squiggle.base.Transactables.Rollback;
 import com.squiggle.base.Transactables.Transactable;
+import com.squiggle.interfaces.Validatable;
 import com.squiggle.output.Output;
+import com.squiggle.output.ToStringer;
 import com.squiggle.parsers.Parser;
 import com.squiggle.parsers.Parserable;
 
@@ -14,9 +18,9 @@ import com.squiggle.parsers.Parserable;
  * @author <a href="joe@truemesh.com">Joe Walnes</a>
  * @author nmadeo - Nicolas Madeo
  */
-public class TransactionQuery extends Parserable {
+public class TransactionQuery extends Parserable implements Validatable {
 
-    List<Transactable> transactables;
+    private List<Transactable> transactables;
 
     public TransactionQuery() {
         super();
@@ -26,6 +30,26 @@ public class TransactionQuery extends Parserable {
     public TransactionQuery(Parser parser) {
         super(parser);
         this.transactables = new LinkedList<Transactable>();
+    }
+
+    public TransactionQuery addInsert(Function<InsertQuery, InsertQuery> queryBuilder) {
+        InsertQuery insert = Squiggle.Insert();
+        return this.add(queryBuilder.apply(insert));
+    }
+
+    public TransactionQuery addSelect(Function<SelectQuery, SelectQuery> queryBuilder) {
+        SelectQuery select = Squiggle.Select();
+        return this.add(queryBuilder.apply(select));
+    }
+
+    public TransactionQuery addDelete(Function<DeleteQuery, DeleteQuery> queryBuilder) {
+        DeleteQuery delete = Squiggle.Delete();
+        return this.add(queryBuilder.apply(delete));
+    }
+
+    public TransactionQuery addUpdate(Function<UpdateQuery, UpdateQuery> queryBuilder) {
+        UpdateQuery update = Squiggle.Update();
+        return this.add(queryBuilder.apply(update));
     }
 
     public TransactionQuery add(Query query) {
@@ -49,7 +73,23 @@ public class TransactionQuery extends Parserable {
     @Override
     public void write(Output out) {
         this.parser.transaction(out, this);
+    }
 
+    public String toString() {
+        validate();
+        return ToStringer.toString(this);
+    }
+
+    @Override
+    public void validate() {
+        if (this.transactables.size() == 0) {
+            throw new IllegalStateException("Cannot make transaction without transactables");
+        }
+
+    }
+
+    public List<Transactable> getTransactables() {
+        return this.transactables;
     }
 
 }

--- a/src/main/java/com/squiggle/queries/UpdateQuery.java
+++ b/src/main/java/com/squiggle/queries/UpdateQuery.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.squiggle.base.*;
+import com.squiggle.builders.CriteriaBuilder;
 import com.squiggle.exceptions.NoColumnsException;
 import com.squiggle.output.*;
 import com.squiggle.parsers.Parserable;

--- a/src/test/java/QueryTests/DeleteQueryTest.java
+++ b/src/test/java/QueryTests/DeleteQueryTest.java
@@ -58,4 +58,11 @@ public class DeleteQueryTest {
                 delete.toString());
     }
 
+    @Test
+    public void deleteWithColumnWithSpaces() {
+        DeleteQuery delete = Squiggle.Delete().from("table").where("column with spaces",
+                column -> column.equals("value"));
+        assertEquals("DELETE FROM table WHERE table.\"column with spaces\" = 'value'", delete.toString());
+    }
+
 }

--- a/src/test/java/QueryTests/DropDatabaseTest.java
+++ b/src/test/java/QueryTests/DropDatabaseTest.java
@@ -9,8 +9,6 @@ import com.squiggle.queries.DropDatabaseQuery;
 
 import org.junit.jupiter.api.Test;
 
-//TODO split this into multiple tests
-
 public class DropDatabaseTest {
 
         @Test

--- a/src/test/java/QueryTests/InsertQueryTest.java
+++ b/src/test/java/QueryTests/InsertQueryTest.java
@@ -100,4 +100,12 @@ public class InsertQueryTest {
                                 insert.toString());
         }
 
+        @Test
+        public void insertWithColumnWithSpaces() {
+                InsertQuery insert = Squiggle.Insert().into("table").to("column with spaces").value("value1");
+                assertEquals(
+                                "INSERT INTO table (\"column with spaces\") VALUES ('value1')",
+                                insert.toString());
+        }
+
 }

--- a/src/test/java/QueryTests/SelectQueryTest.java
+++ b/src/test/java/QueryTests/SelectQueryTest.java
@@ -81,4 +81,22 @@ public class SelectQueryTest {
                 select.toString());
     }
 
+    @Test
+    public void simpleStringWhere() {
+        SelectQuery select = Squiggle.Select().from("table").select("*").where("column", c -> c.equals("value"));
+        assertEquals("SELECT table.* FROM table WHERE table.column = 'value'", select.toString());
+    }
+
+    @Test
+    public void simpleIntWhere() {
+        SelectQuery select = Squiggle.Select().from("table").select("*").where("column", c -> c.equals(1));
+        assertEquals("SELECT table.* FROM table WHERE table.column = 1", select.toString());
+    }
+
+    @Test
+    public void multiWhereColumn() {
+        SelectQuery select = Squiggle.Select().from("table").select("*").where("column1", c -> c.equals(1))
+                .where("column2", c -> c.equals(2));
+        assertEquals("SELECT table.* FROM table WHERE table.column1 = 1 AND table.column2 = 2", select.toString());
+    }
 }

--- a/src/test/java/QueryTests/SelectQueryTest.java
+++ b/src/test/java/QueryTests/SelectQueryTest.java
@@ -99,4 +99,10 @@ public class SelectQueryTest {
                 .where("column2", c -> c.equals(2));
         assertEquals("SELECT table.* FROM table WHERE table.column1 = 1 AND table.column2 = 2", select.toString());
     }
+
+    @Test
+    public void selectWithColumnWithSpaces() {
+        SelectQuery select = Squiggle.Select().from("table").select("Column 1", "alias");
+        assertEquals("SELECT table.\"Column 1\" AS alias FROM table", select.toString());
+    }
 }

--- a/src/test/java/QueryTests/TransactionQueryTest.java
+++ b/src/test/java/QueryTests/TransactionQueryTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.Test;
 
 public class TransactionQueryTest {
 
+    // TODO ADD TEST COMMITTED AND ROLLBACK IN THE SAME.
+    // TODO ADD NAMED TRANSACTIONS TO ROLLBACK IF CONDITION.
     @Test
     public void simpleEmptyTransaction() {
         TransactionQuery tsQuery = Squiggle.Transaction().commit();
-        assertEquals("BEGIN TRANSACTION", tsQuery.toString());
+        assertEquals("BEGIN TRANSACTION COMMIT TRANSACTION", tsQuery.toString());
     }
 
     @Test

--- a/src/test/java/QueryTests/TransactionQueryTest.java
+++ b/src/test/java/QueryTests/TransactionQueryTest.java
@@ -1,0 +1,105 @@
+package QueryTests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.squiggle.Squiggle;
+import com.squiggle.queries.TransactionQuery;
+
+import org.junit.jupiter.api.Test;
+
+public class TransactionQueryTest {
+
+    @Test
+    public void simpleEmptyTransaction() {
+        TransactionQuery tsQuery = Squiggle.Transaction().commit();
+        assertEquals("BEGIN TRANSACTION", tsQuery.toString());
+    }
+
+    @Test
+    public void simpleInsertTransactionCommitted() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addInsert(query -> query.into("table").to("column1").value(2))
+                .commit();
+        assertEquals("BEGIN TRANSACTION INSERT INTO table (column1) VALUES (2) COMMIT TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    // TODO check space in =. why is it column1=2 and not column1 = 2?
+    public void simpleUpdateTransactionCommitted() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addUpdate(query -> query.table("table").set("column1").to(2))
+                .commit();
+        assertEquals("BEGIN TRANSACTION UPDATE table SET table.column1=2 COMMIT TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleDeleteTransactionCommitted() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addDelete(query -> query.from("table").where("column1", c -> c.equals(2)))
+                .commit();
+        assertEquals("BEGIN TRANSACTION DELETE FROM table WHERE table.column1 = 2 COMMIT TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleSelectTransactionCommitted() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addSelect(query -> query.from("table").select("*").where("column1", c -> c.equals(2)))
+                .commit();
+        assertEquals("BEGIN TRANSACTION SELECT table.* FROM table WHERE table.column1 = 2 COMMIT TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleSelectTransactionRolledBack() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addSelect(query -> query.from("table").select("*").where("column1", c -> c.equals(2)))
+                .rollback();
+        assertEquals("BEGIN TRANSACTION SELECT table.* FROM table WHERE table.column1 = 2 ROLLBACK TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleInsertTransactionRolledBack() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addSelect(query -> query.from("table").select("*").where("column1", c -> c.equals(2)))
+                .rollback();
+        assertEquals("BEGIN TRANSACTION SELECT table.* FROM table WHERE table.column1 = 2 ROLLBACK TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleDeleteTransactionRolledBack() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addDelete(query -> query.from("table").where("column1", c -> c.equals(2)))
+                .rollback();
+        assertEquals("BEGIN TRANSACTION DELETE FROM table WHERE table.column1 = 2 ROLLBACK TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void simpleUpdateTransactionRolledBack() {
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addUpdate(query -> query.table("table").set("column1").to(2))
+                .rollback();
+        assertEquals("BEGIN TRANSACTION UPDATE table SET table.column1=2 ROLLBACK TRANSACTION",
+                tsQuery.toString());
+    }
+
+    @Test
+    public void composedTransactionCommitted() {
+        String table = "table";
+        TransactionQuery tsQuery = Squiggle.Transaction()
+                .addInsert(query -> query.into(table).to("column1").value(2))
+                .addSelect(query -> query.from(table).select("*").where("column1", c -> c.equals(2)))
+                .addDelete(query -> query.from(table).where("column1", c -> c.equals(2)))
+                .addUpdate(query -> query.table(table).set("column1").to(2))
+                .commit();
+        assertEquals(
+                "BEGIN TRANSACTION INSERT INTO table (column1) VALUES (2) SELECT table.* FROM table WHERE table.column1 = 2 DELETE FROM table WHERE table.column1 = 2 UPDATE table SET table.column1=2 COMMIT TRANSACTION",
+                tsQuery.toString());
+    }
+
+}

--- a/src/test/java/QueryTests/UpdateQueryTest.java
+++ b/src/test/java/QueryTests/UpdateQueryTest.java
@@ -64,4 +64,10 @@ public class UpdateQueryTest {
                 + value2 + ", table.column4=" + value3 + " WHERE table.whereColumn = " + value4, update.toString());
     }
 
+    @Test
+    public void updateWithColumnWithSpaces() {
+        UpdateQuery update = Squiggle.Update().table("table").set("column with spaces").to("value");
+        assertEquals("UPDATE table SET table.\"column with spaces\"='value'", update.toString());
+    }
+
 }


### PR DESCRIPTION
- fix multiple where error
- commit and rollback added
- Transaction Query added
- Transactable interface added
- super invocation removed from Constraint
- Query now implements Transactable
- CriteriaBuilder moved to builders folder
- Table is now parsed by parser
- Transactable imports updated
- tables and columns with spaces in the name are now accepted
- TransactionQuery can create Queries on method
- TransactionQueryTest added.